### PR TITLE
fix: save file as tmp file

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [ring/ring-json "0.3.1"]
                  [compojure "1.4.0"]
                  [prismatic/schema "0.4.3"]
-                 [http-kit "2.1.18"]
+                 [clj-http "2.1.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [log4j/log4j "1.2.17"]
                  [environ "0.5.0"]]

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -4,3 +4,5 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 
 # Print the date in ISO 8601 format
 log4j.appender.console.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
+
+log4j.logger.org.apache.http=ERROR

--- a/src/featured_gml/zip.clj
+++ b/src/featured_gml/zip.clj
@@ -1,12 +1,12 @@
 (ns featured-gml.zip
   (:require [clojure.java.io :as io]
             [clojure.tools.logging :as log])
-  (:import (java.util.zip ZipOutputStream ZipEntry)))
+  (:import (java.util.zip ZipOutputStream ZipFile ZipEntry)))
 
-(defn entries [zipfile]
- (lazy-seq
-  (if-let [entry (.getNextEntry zipfile)]
-   (cons entry (entries zipfile)))))
+(defn xml-entries [^ZipFile zipfile]
+  (filter (fn [e] (and #(not (.isDirectory e))
+                       (or (.endsWith (.getName e) "xml")
+                           (.endsWith (.getName e) "gml")))) (enumeration-seq (.entries zipfile))))
 
 (defn zip-file [uncompressed-file]
   "Return zip-file location with zipped content of uncompressed-file"


### PR DESCRIPTION
* caching causes heap overflows
* uses clj-http instead of http-kit, async was too difficult at the moment. First we need a serious fixup for the web api.